### PR TITLE
include select l10n

### DIFF
--- a/do.sh
+++ b/do.sh
@@ -18,7 +18,13 @@ for ARCH in "$@"; do
     TARGET="$LOCATION/linuxcnc-stretch-uspace-$ARCH.iso"
     lwr -o "$TARGET" \
         --architecture=$ARCH \
-        -t "live-task-base task-xfce-desktop" \
+        -t "live-task-base task-xfce-desktop \
+            task-german-desktop task-spanish-desktop task-finnish-desktop \
+            task-hungarian-desktop task-italian-desktop task-japanese-desktop \
+            task-polish-desktop task-brazilian-portuguese-desktop \
+            task-romanian-desktop task-russian-desktop task-slovak-desktop \
+            task-serbian-desktop task-swedish-desktop task-chinese-s-desktop \
+            task-chinese-t-desktop" \
         -e "linux-image-rt-$KARCH linux-headers-rt-$KARCH firmware-linux \
             linuxcnc-uspace linuxcnc-uspace-dev hostmot2-firmware-all" \
         --description="Unofficial LinuxCNC 'Stretch' $ARCH Live/Install"


### PR DESCRIPTION
.. include every language that linuxcnc has a .po (no matter how incomplete)

No l10n:     1.1GB
select l10n: 1.6GB (+.5GB)
full l10n:   2.0GB (+.9GB)